### PR TITLE
chore: rename master to main in workflow triggers and branch refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release Please Workflow
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/update-version-header.yml
+++ b/.github/workflows/update-version-header.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out the release-please--branches--master branch
         uses: actions/checkout@v4
         with:
-          ref: release-please--branches--master
+          ref: release-please--branches--main
       
       
       - name: Update Version Header
@@ -79,6 +79,6 @@ jobs:
             echo "No changes to commit, skipping commit step"
           else
             git commit -m "chore: Update version header file"
-            git push origin release-please--branches--master
+            git push origin release-please--branches--main
           fi
 


### PR DESCRIPTION
## Summary
- Updated `release.yml` push trigger from `master` → `main`
- Updated `update-version-header.yml` checkout ref and push target from `release-please--branches--master` → `release-please--branches--main`

## Test plan
- [ ] Confirm release-please workflow triggers on push to main
- [ ] Confirm update-version-header checks out and pushes to the correct release-please branch on next release