### PR TITLE
fix: update Discord invite URL to correct server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Contributions
 Contact
 -------
 - Feel free to reach out to me on the [Unreal Slackers](https://discord.gg/unreal-slackers) discord. I'm @Fragmanget_. There is a ton of other Unreal programmers up there, so if I'm not around to help, someone else may be able to get you going.
-- You can also reach me on my personal [Discord Server](https://discord.gg/TSKHvVFYxB) (@cptvideo),
+- You can also reach me on my personal [Discord Server](https://discord.gg/TN6XJSNK5Y) (@cptvideo),
 via [LinkedIn](https://www.linkedin.com/in/scottkirvan/), or [email](mailto://ScooterUtils@skvfx.com).
 
 

--- a/notes/USER_README.md
+++ b/notes/USER_README.md
@@ -280,7 +280,7 @@ Rate/review the plugin on [fab.com](http://fab.com/) or donate to support develo
 ## Support/Contact
 
 - Find me on the [Unreal Slackers](https://discord.gg/unreal-slackers) Discord as @Fragmanget_. Tons of other Unreal programmers hang out there too
-- You can also reach me on my personal [Discord Server](https://discord.gg/TSKHvVFYxB) (@cptvideo), via [LinkedIn](https://www.linkedin.com/in/scottkirvan/), or [email](mailto:ScooterUtils@skvfx.com)
+- You can also reach me on my personal [Discord Server](https://discord.gg/TN6XJSNK5Y) (@cptvideo), via [LinkedIn](https://www.linkedin.com/in/scottkirvan/), or [email](mailto:ScooterUtils@skvfx.com)
 
 ## Credits
 


### PR DESCRIPTION
## Summary
- Updates Discord invite URL from `discord.gg/TSKHvVFYxB` to the correct `discord.gg/TN6XJSNK5Y` across all markdown and workflow files

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
**Steps to verify:**
1. Search this repo for `TSKHvVFYxB` — should return no results
2. Confirm Discord links point to `discord.gg/TN6XJSNK5Y`

**Expected result:** All Discord links use the correct invite URL.

**Test environment:**
- GitHub web UI / text search

## Checklist
- [x] I have performed a self-review of my own code
- [x] No stale Discord invite URLs remain in this repo