### PR TITLE
fix: add workflow_dispatch to docs deploy and update hero links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: ['docs/**']
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,7 @@ hero:
     - theme: alt
       text: Discord
       link: https://discord.gg/TN6XJSNK5Y
+    - theme: alt
+      text: User Guide
+      link: https://www.scottkirvan.com/ScooterUtils/
 ---


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `docs.yml` so the VitePress deploy can be run manually at any time (`gh workflow run docs.yml --repo ScottKirvan/ScooterUtils`)
- Touching `docs/index.md` (added User Guide action button) ensures the merge commit matches the `docs/**` path filter and triggers the deploy immediately on merge, overriding the stale branch-based README deployment

## Test plan

- [ ] Merge this PR
- [ ] Verify `Deploy Docs to GitHub Pages` workflow runs and succeeds
- [ ] Verify `https://www.scottkirvan.com/ScooterUtils/` shows VitePress site, not README