### PR TITLE
fix: rename product to UE ScooterUtils and add discord emoji

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: ['docs/**']
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,13 @@ jobs:
         📖 [User Guide](https://www.scottkirvan.com/ScooterUtils/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/ScooterUtils/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/ScooterUtils/issues/new?template=feature_request.md)
     secrets: inherit
 
+  update-changelog-prs:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-update-changelog-prs.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+
   discord-notify:
     needs: [release-please, improve-release-notes]
     if: ${{ needs.release-please.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-      project_name: "ScooterUtils"
-      project_context: "ScooterUtils is an Unreal Engine utility plugin providing helpful development tools and utilities for Unreal Engine projects."
+      project_name: "UE ScooterUtils"
+      project_context: "UE ScooterUtils is an Unreal Engine utility plugin providing helpful development tools and utilities for Unreal Engine projects."
       header: |
-        ## ScooterUtils
+        ## UE ScooterUtils
 
         > Unreal Engine utility plugin for developers.
 
@@ -49,5 +49,6 @@ jobs:
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-      project_name: "ScooterUtils"
+      project_name: "UE ScooterUtils"
+      emoji: "🛵"
     secrets: inherit

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,7 @@ hero:
     - theme: alt
       text: Discord
       link: https://discord.gg/TN6XJSNK5Y
+    - theme: alt
+      text: User Guide
+      link: https://www.scottkirvan.com/ScooterUtils/
 ---


### PR DESCRIPTION
## Summary
- Renames product from "ScooterUtils" to "UE ScooterUtils" in release notes and Discord announcements
- Passes `emoji: "🛵"` to `reusable-discord-notify.yml`

## Notes
Depends on [ScottKirvan/.github#8](https://github.com/ScottKirvan/.github/pull/8) being merged first. Merge order: `.github#8` → this PR.

## Test plan
- [ ] Merge ScottKirvan/.github#8 first
- [ ] Merge this PR
- [ ] Trigger a release and verify Discord message shows 🛵 and product name "UE ScooterUtils"