### PR TITLE
feat: add pre-release staging workflow, update release pipeline

### DIFF
--- a/.github/workflows/pre-release-staging.yml
+++ b/.github/workflows/pre-release-staging.yml
@@ -1,20 +1,22 @@
-name: Manual — Preview Release Notes
+name: Manual — Pre-Release Staging
 
 on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Anticipated next version tag (e.g. v1.2.0) — need not exist yet
-        required: true
+        description: Version tag override — leave blank to infer from open release-please PR
+        required: false
         type: string
+        default: ""
 
 permissions:
   contents: write
   models: read
+  pull-requests: read
 
 jobs:
-  preview:
-    uses: ScottKirvan/.github/.github/workflows/reusable-preview-release-notes.yml@main
+  stage:
+    uses: ScottKirvan/.github/.github/workflows/reusable-pre-release-staging.yml@main
     with:
       tag_name: ${{ inputs.tag_name }}
       project_name: "UE ScooterUtils"
@@ -27,6 +29,4 @@ jobs:
         🫶❤️[Support this project](https://ko-fi.com/ScottKirvan) · 📖 [User Guide](https://www.scottkirvan.com/ScooterUtils/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/ScooterUtils/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/ScooterUtils/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/ScooterUtils/blob/main/notes/CHANGELOG.md)
 
         ---
-      footer: ""
-      changelog_path: ""
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,54 @@ jobs:
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
 
-  improve-release-notes:
+  apply-staged-notes:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    outputs:
+      used_staging: ${{ steps.apply.outputs.used_staging }}
+      discord_blurb: ${{ steps.apply.outputs.discord_blurb }}
+    steps:
+      - name: Apply staged notes and clean up
+        id: apply
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          STAGING_BRANCH="pre-release-staging/$TAG"
+
+          if ! gh api "repos/$REPO/branches/$STAGING_BRANCH" > /dev/null 2>&1; then
+            echo "used_staging=false" >> "$GITHUB_OUTPUT"
+            echo "No staging branch found for $TAG — will fall back to AI generation"
+            exit 0
+          fi
+
+          echo "Found staging branch: $STAGING_BRANCH"
+
+          NOTES=$(gh api "repos/$REPO/contents/.github/tmp/pre-release-staging/release-notes.md?ref=$STAGING_BRANCH" \
+            --jq '.content' | base64 -d)
+          BLURB=$(gh api "repos/$REPO/contents/.github/tmp/pre-release-staging/discord-blurb.txt?ref=$STAGING_BRANCH" \
+            --jq '.content' | base64 -d 2>/dev/null || echo "")
+
+          printf '%s' "$NOTES" > /tmp/staged-release-notes.md
+          gh release edit "$TAG" --repo "$REPO" --notes-file /tmp/staged-release-notes.md
+          echo "Applied staged release notes to $TAG"
+
+          gh api "repos/$REPO/git/refs/heads/$STAGING_BRANCH" --method DELETE || true
+          echo "Deleted staging branch: $STAGING_BRANCH"
+
+          echo "used_staging=true" >> "$GITHUB_OUTPUT"
+          { echo 'discord_blurb<<BLURB_EOF'
+            printf '%s\n' "$BLURB"
+            echo 'BLURB_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  improve-release-notes:
+    needs: [release-please, apply-staged-notes]
+    if: >-
+      needs.release-please.outputs.release_created == 'true' &&
+      needs.apply-staged-notes.outputs.used_staging == 'false'
     uses: ScottKirvan/.github/.github/workflows/reusable-release-notes.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
@@ -53,12 +98,15 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
 
   discord-notify:
-    needs: [release-please, improve-release-notes]
-    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please, apply-staged-notes, improve-release-notes]
+    if: >-
+      always() &&
+      needs.release-please.outputs.release_created == 'true' &&
+      !failure() && !cancelled()
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "UE ScooterUtils"
       emoji: "🛵"
-      discord_blurb: ${{ needs.improve-release-notes.outputs.discord_blurb }}
+      discord_blurb: ${{ needs.apply-staged-notes.outputs.discord_blurb || needs.improve-release-notes.outputs.discord_blurb }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `pre-release-staging.yml` — run this manually before a release to generate AI notes, save the full assembled body (header + notes + footer) to a staging branch, and create/update a draft GitHub release for review and editing
- Updates `release.yml` (or `release-please.yml`) with a new `apply-staged-notes` job: checks for a `pre-release-staging/{tag}` branch via API exit code (avoids the `gh api --jq` null-on-404 false-positive bug), reads notes and discord blurb via API, applies them to the release, and deletes the staging branch
- `improve-release-notes` is now conditional on `used_staging == 'false'` — it only runs when no staging branch was found
- `discord-notify` now uses `always() && !failure() && !cancelled()` and passes the blurb from whichever path ran
- Removes `preview-release-notes.yml` — superseded by the new staging workflow

## Test plan

- [ ] Merge this PR
- [ ] Run `Manual — Pre-Release Staging` in Actions (leave tag blank to auto-infer from open release-please PR)
- [ ] Check the staging branch and draft release; edit if needed
- [ ] Trigger a release and confirm staged notes are applied and the staging branch is deleted
- [ ] Confirm fallback AI generation works on a release with no staging branch