### PR TITLE
feat: add self-hosted Unreal plugin build job for UE 5.4–5.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,41 @@ jobs:
       changelog_path: ""
     secrets: inherit
 
+  build-plugin:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: [self-hosted, windows, unreal]
+    strategy:
+      matrix:
+        ue_version: ['5.4', '5.5', '5.6', '5.7', '5.8']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build plugin for UE ${{ matrix.ue_version }}
+        shell: powershell
+        run: |
+          $UAT = "D:\bin\Epic Games\UE_${{ matrix.ue_version }}\Engine\Build\BatchFiles\RunUAT.bat"
+          $plugin = "${{ github.workspace }}\ScooterUtils.uplugin"
+          $output = "${{ github.workspace }}\build\UE_${{ matrix.ue_version }}"
+          & $UAT BuildPlugin -Plugin="$plugin" -Package="$output" -Rocket
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Package artifact
+        shell: powershell
+        run: |
+          $zipName = "ScooterUtils-UE${{ matrix.ue_version }}-Win64.zip"
+          Compress-Archive -Path "build\UE_${{ matrix.ue_version }}\*" -DestinationPath $zipName
+          Write-Host "Created: $zipName"
+
+      - name: Upload to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            "ScooterUtils-UE${{ matrix.ue_version }}-Win64.zip" --clobber
+
   update-changelog-prs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
## Summary

- Adds a `build-plugin` job to `release.yml` that runs on the TheHumanTon self-hosted runner
- Builds the plugin against UE 5.4, 5.5, 5.6, 5.7, and 5.8 in parallel using a matrix strategy
- `fail-fast: false` so a failure on one UE version doesn't cancel the others
- Uploads each build as a zip (`ScooterUtils-UE5.x-Win64.zip`) to the GitHub release

## Prerequisites

- TheHumanTon must be registered as a runner and the service running (see setup notes)
- UE versions installed at `D:\bin\Epic Games\UE_5.x\`

## User Testing / Acceptance

1. Merge this PR, then trigger a release (or manually dispatch the workflow)
2. Confirm the `build-plugin` job appears in Actions with 5 parallel matrix runs
3. Confirm each run produces a zip attached to the GitHub release
4. Confirm a failed UE version does not cancel the others