### PR TITLE
fix: bypass PowerShell execution policy on self-hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build plugin for UE ${{ matrix.ue_version }}
-        shell: powershell
+        shell: powershell -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           $UAT = "D:\bin\Epic Games\UE_${{ matrix.ue_version }}\Engine\Build\BatchFiles\RunUAT.bat"
           $plugin = "${{ github.workspace }}\ScooterUtils.uplugin"
@@ -111,7 +111,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Package artifact
-        shell: powershell
+        shell: powershell -ExecutionPolicy Bypass -Command ". '{0}'"
         run: |
           $zipName = "ScooterUtils-UE${{ matrix.ue_version }}-Win64.zip"
           Compress-Archive -Path "build\UE_${{ matrix.ue_version }}\*" -DestinationPath $zipName


### PR DESCRIPTION
## Summary

- Changes `shell: powershell` to `shell: powershell -ExecutionPolicy Bypass -Command ". '{0}'"` on the two PowerShell build steps
- The runner service account has `Restricted` execution policy that `Set-ExecutionPolicy RemoteSigned -Scope LocalMachine` does not override; the bypass flag resolves this without changing machine policy

## Test plan

- [ ] Merge and verify all five `build-plugin` matrix jobs pass on the next release run
- [ ] Confirm zips are uploaded to the release assets