### PR TITLE
fix: serialize builds and strip Intermediate from plugin packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
       matrix:
         ue_version: ['5.4', '5.5', '5.6', '5.7', '5.8']
       fail-fast: false
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -109,6 +110,15 @@ jobs:
           $output = "${{ github.workspace }}\build\UE_${{ matrix.ue_version }}"
           & $UAT BuildPlugin -Plugin="$plugin" -Package="$output" -Rocket
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Clean build output
+        shell: powershell -ExecutionPolicy Bypass -Command ". '{0}'"
+        run: |
+          $intermediate = "build\UE_${{ matrix.ue_version }}\Intermediate"
+          if (Test-Path $intermediate) {
+            Remove-Item -Recurse -Force $intermediate
+            Write-Host "Removed Intermediate folder"
+          }
 
       - name: Package artifact
         shell: powershell -ExecutionPolicy Bypass -Command ". '{0}'"


### PR DESCRIPTION
## Summary

- `max-parallel: 1` on the build matrix — prevents all five UE version builds running simultaneously on a single machine
- Adds a "Clean build output" step between build and package that removes the `Intermediate/` folder from the RunUAT output before zipping — keeps release asset ZIPs clean

## Test plan

- [ ] Merge and verify builds run one at a time on the self-hosted runner
- [ ] Confirm release asset ZIPs do not contain an `Intermediate/` folder