### PR TITLE
fix: restrict plugin build to Win64 target platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           $UAT = "D:\bin\Epic Games\UE_${{ matrix.ue_version }}\Engine\Build\BatchFiles\RunUAT.bat"
           $plugin = "${{ github.workspace }}\ScooterUtils.uplugin"
           $output = "${{ github.workspace }}\build\UE_${{ matrix.ue_version }}"
-          & $UAT BuildPlugin -Plugin="$plugin" -Package="$output" -Rocket
+          & $UAT BuildPlugin -Plugin="$plugin" -Package="$output" -Rocket -TargetPlatforms=Win64
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Clean build output


### PR DESCRIPTION
## Summary

- Adds `-TargetPlatforms=Win64` to the `BuildPlugin` command
- Without this flag, RunUAT infers target platforms from the `.uplugin` manifest (which includes Android) and tries to build for all of them — failing because the Android SDK is not installed on the self-hosted runner

## Test plan

- [ ] Merge and verify all five `build-plugin` matrix jobs complete successfully
- [ ] Confirm Win64 ZIPs are uploaded to the release assets