### PR TITLE
fix: restrict CI builds to Win64 pending Android platform setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           $UAT = "D:\bin\Epic Games\UE_${{ matrix.ue_version }}\Engine\Build\BatchFiles\RunUAT.bat"
           $plugin = "${{ github.workspace }}\ScooterUtils.uplugin"
           $output = "${{ github.workspace }}\build\UE_${{ matrix.ue_version }}"
-          & $UAT BuildPlugin -Plugin="$plugin" -Package="$output" -Rocket
+          & $UAT BuildPlugin -Plugin="$plugin" -Package="$output" -Rocket -TargetPlatforms=Win64
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Clean build output


### PR DESCRIPTION
## Summary

- Adds `-TargetPlatforms=Win64` to the `BuildPlugin` command to skip Android builds until Android platform support is properly installed on the runner
- Tracked in #107

## Test plan

- [ ] Merge and verify all five `build-plugin` matrix jobs pass
- [ ] Confirm Win64 ZIPs appear in release assets