### PR TITLE
fix: narrow build matrix to 5.7 for debugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: [self-hosted, windows, unreal]
     strategy:
       matrix:
-        ue_version: ['5.4', '5.5', '5.6', '5.7', '5.8']
+        ue_version: ['5.7']
       fail-fast: false
       max-parallel: 1
     steps:


### PR DESCRIPTION
Temporary — narrows matrix to UE 5.7 only to speed up debugging the build pipeline. Revert to full matrix once builds pass.