### PR TITLE
fix: use PowerShell for release upload, narrow matrix to 5.7 for debug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,12 +128,11 @@ jobs:
           Write-Host "Created: $zipName"
 
       - name: Upload to release
-        shell: bash
+        shell: powershell -ExecutionPolicy Bypass -Command ". '{0}'"
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            "ScooterUtils-UE${{ matrix.ue_version }}-Win64.zip" --clobber
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" "ScooterUtils-UE${{ matrix.ue_version }}-Win64.zip" --clobber
 
   update-changelog-prs:
     needs: release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: [self-hosted, windows, unreal]
     strategy:
       matrix:
-        ue_version: ['5.4', '5.5', '5.6', '5.7', '5.8']
+        ue_version: ['5.7']
       fail-fast: false
       max-parallel: 1
     steps:


### PR DESCRIPTION
## Summary

- `shell: bash` on the upload step resolves to WSL `bash.exe` on Windows runners; WSL distros are per-user and not visible to the `NetworkService` runner account — switched to PowerShell
- Matrix narrowed to `['5.7']` temporarily for faster debug iteration (restore to full matrix once a clean end-to-end pass confirms the pipeline works)

## Test plan

- [ ] Merge and verify the 5.7 build job completes: build → clean → package → upload all pass
- [ ] Confirm `ScooterUtils-UE5.7-Win64.zip` appears in the release assets