### PR TITLE
fix: restore full UE matrix, wait for builds before Discord notify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: [self-hosted, windows, unreal]
     strategy:
       matrix:
-        ue_version: ['5.7']
+        ue_version: ['5.4', '5.5', '5.6', '5.7', '5.8']
       fail-fast: false
       max-parallel: 1
     steps:
@@ -142,7 +142,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
 
   discord-notify:
-    needs: [release-please, apply-staged-notes, improve-release-notes]
+    needs: [release-please, apply-staged-notes, improve-release-notes, build-plugin]
     if: >-
       always() &&
       needs.release-please.outputs.release_created == 'true' &&


### PR DESCRIPTION
## Summary

- Restores build matrix to all five UE versions (5.4–5.8) after debug pass confirmed pipeline works on 5.7
- Adds `build-plugin` to `discord-notify` needs so Discord notification fires only after all ZIPs are uploaded — previously Discord fired in parallel with builds, so users who clicked the release link immediately saw no assets

## Test plan

- [ ] Merge and verify all five `build-plugin` jobs pass on next release
- [ ] Confirm Discord notification arrives after all ZIPs are attached to the release