### PR TITLE
fix: UE 5.8 FJsonObject key type compatibility in JSONBlueprintLibrary

### DIFF
--- a/Source/ScooterUtilsBPLibrary/Private/JSONBlueprintLibrary.cpp
+++ b/Source/ScooterUtilsBPLibrary/Private/JSONBlueprintLibrary.cpp
@@ -256,10 +256,10 @@ bool UJSONBlueprintLibrary::IsFieldNull(const FString &JSONString, const FString
         return false;
     }
 
-    const TSharedPtr<FJsonValue> *FieldValue = JSONObject->Values.Find(FieldName);
-    if (FieldValue && FieldValue->IsValid())
+    TSharedPtr<FJsonValue> FieldValue = JSONObject->TryGetField(FieldName);
+    if (FieldValue.IsValid())
     {
-        return (*FieldValue)->IsNull();
+        return FieldValue->IsNull();
     }
 
     return false;
@@ -404,7 +404,11 @@ bool UJSONBlueprintLibrary::GetAllFieldNames(const FString &JSONString, TArray<F
     OutFieldNames.Empty();
     for (const auto &Entry : JSONObject->Values)
     {
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+        OutFieldNames.Add(FString(Entry.Key.ToStringView()));
+#else
         OutFieldNames.Add(Entry.Key);
+#endif
     }
 
     return true;


### PR DESCRIPTION
## Summary

UE 5.8 changed `FJsonObject::Values` map key type from `FString` to `UE::FSharedString`, breaking two call sites in `JSONBlueprintLibrary.cpp`:

- **Line 259** (`IsFieldNull`): Replaced `Values.Find(FieldName)` with `JSONObject->TryGetField(FieldName)` — uses the public API which handles the key type internally, no version guard needed
- **Line 407** (`GetFieldNames`): Version-gated `Entry.Key` access — on 5.8+ converts `UE::FSharedString` to `FString` via `ToStringView()`; on earlier versions uses `FString` key directly

## Test plan

- [ ] Merge and verify `build-plugin (5.8)` passes in CI
- [ ] Verify `build-plugin (5.4–5.7)` still pass (no regression on earlier versions)