### PR TITLE
fix: include Version.h for ENGINE_MAJOR_VERSION macro in JSONBlueprintLibrary

### DIFF
--- a/Source/ScooterUtilsBPLibrary/Private/JSONBlueprintLibrary.cpp
+++ b/Source/ScooterUtilsBPLibrary/Private/JSONBlueprintLibrary.cpp
@@ -4,6 +4,7 @@
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonReader.h"
 #include "DebugPrint.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 // ========== Helper Functions (not class members) ==========
 


### PR DESCRIPTION
## Summary

`ENGINE_MAJOR_VERSION` and `ENGINE_MINOR_VERSION` macros were not visible in `JSONBlueprintLibrary.cpp` — not pulled in transitively by the existing includes — causing `C4668` (undefined macro treated as 0), which is a fatal error under `-WarningsAsErrors`. Adds `Runtime/Launch/Resources/Version.h` explicitly to resolve it.

## Test plan

- [ ] Merge and verify all five `build-plugin` jobs pass, including 5.4 and 5.8