### PR TITLE
fix: use operator* for cross-version FJsonObject key conversion

### DIFF
--- a/Source/ScooterUtilsBPLibrary/Private/JSONBlueprintLibrary.cpp
+++ b/Source/ScooterUtilsBPLibrary/Private/JSONBlueprintLibrary.cpp
@@ -4,7 +4,6 @@
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonReader.h"
 #include "DebugPrint.h"
-#include "Runtime/Launch/Resources/Version.h"
 
 // ========== Helper Functions (not class members) ==========
 
@@ -405,11 +404,7 @@ bool UJSONBlueprintLibrary::GetAllFieldNames(const FString &JSONString, TArray<F
     OutFieldNames.Empty();
     for (const auto &Entry : JSONObject->Values)
     {
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
-        OutFieldNames.Add(FString(Entry.Key.ToStringView()));
-#else
-        OutFieldNames.Add(Entry.Key);
-#endif
+        OutFieldNames.Add(FString(*Entry.Key));
     }
 
     return true;


### PR DESCRIPTION
## Summary

- Removes `#include "Runtime/Launch/Resources/Version.h"` (was added for version guards that are no longer needed)
- Replaces the version-guarded block in `GetAllFieldNames` with a single cross-version line: `OutFieldNames.Add(FString(*Entry.Key))`
- `operator*()` returns `const TCHAR*` on both `FString` (pre-5.8) and `UE::TSharedString<TCHAR>` (5.8+), making version guards unnecessary

## Test plan

- [ ] UE 5.4 build passes
- [ ] UE 5.5 build passes
- [ ] UE 5.6 build passes
- [ ] UE 5.7 build passes
- [ ] UE 5.8 build passes (was failing with `error C2665` on `Values` key type)